### PR TITLE
feat: ブランチ作成前のmain最新化手順を追加

### DIFF
--- a/.claude/rules/git-conventions.md
+++ b/.claude/rules/git-conventions.md
@@ -16,10 +16,10 @@ globs: []
 新しいブランチを作成する前に、必ずmainを最新化する:
 
 1. `git checkout main`
-2. `git pull origin main`
-3. `git checkout -b {type}/{issue番号}-{説明}`
+2. `git pull --ff-only origin main`
+3. `git checkout -b {type}/{issue番号}-{英語の短い説明}`
 
-※ worktree使用時は `git fetch origin main` の後に `git worktree add ... origin/main` で最新のmainから作成される
+※ worktree使用時は `git fetch origin main` の後に `git worktree add <path> -b {type}/{issue番号}-{英語の短い説明} origin/main` で最新のmainからブランチを作成する
 
 ## コミットメッセージ
 


### PR DESCRIPTION
## Summary

- git-conventions.mdにブランチ作成前のmain最新化手順を追加
- 通常のブランチ作成（checkout）とworktree使用時の両方をカバー

## 変更内容

- `.claude/rules/git-conventions.md`: ブランチ命名セクション直後に「ブランチ作成手順」セクションを新設

## Test plan

- [ ] git-conventions.mdの内容が正しく、手順が明確であることを確認
- [ ] 既存のセクション構成と整合していることを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)