### PR TITLE
feat: レビュー対応中のポーリング一時停止・再開機能を追加

### DIFF
--- a/.claude/commands/review-respond.md
+++ b/.claude/commands/review-respond.md
@@ -55,7 +55,7 @@ PRのレビューコメントを取得し、対応してください。
   - 内容: 連続空振り回数（整数値のみ）
 - **cronタスクIDファイル**: `/tmp/{project}-review-{ownerRepo}-cron-{PR番号}`
   - 内容: `/loop` 作成時のcronタスクID（CronCreate の戻り値）
-  - このファイルは `/loop` 起動元（`issue-start --parallel --auto` フロー内、または手動の `/loop`）が作成する。`review-respond` は読み取りのみ
+  - 初回作成は `/loop` 起動元（`issue-start --parallel --auto` フロー内、または手動の `/loop`）が行う。`review-respond` はポーリング一時停止時に読み取り、再開時に新しいタスクIDで上書きする
 - **スコープ外Issue候補ファイル**: `/tmp/{project}-review-{ownerRepo}-deferred-{PR番号}`
   - 内容: スコープ外と判断したレビューコメントのうち、将来のIssue候補となるものをJSON Lines形式で蓄積
   - 各行のフォーマット（1行1オブジェクト）: `{"comment_id": "<comment id>" | null, "review_id": "<review id>" | null, "kind": "line_comment" | "review_body", "path": "<ファイルパス>" | null, "line": <行番号> | null | "N/A", "summary": "<改善内容の要約>"}`
@@ -282,7 +282,7 @@ gh api --paginate repos/{owner}/{repo}/pulls/{PR番号}/reviews | jq -s '
 
 ### 3. コード修正の実施
 
-**ポーリング一時停止**（`--auto` モード時）: コード修正に入る前に、cronタスクIDファイル（`/tmp/{project}-review-{ownerRepo}-cron-{PR番号}`）からタスクIDを読み取り、`CronDelete` でポーリングを停止する。これにより修正中に次のポーリングが走ることを防ぐ。タスクIDファイルが存在しない、またはタスクIDが取得できない場合はスキップする。
+**ポーリング一時停止**（`--auto` モード時）: コード修正に入る前に、cronタスクIDファイル（`/tmp/{project}-review-{ownerRepo}-cron-{PR番号}`）からタスクIDを読み取り、`CronDelete` でポーリングを停止する。これにより修正中に次のポーリングが走ることを防ぐ。タスクIDファイルが存在しない、またはタスクIDが取得できない場合は、`--max-idle` 停止時と同様に `CronList` から対象コマンド完全一致のタスクを特定して `CronDelete` するフォールバックを行う。それでもタスクを特定できない場合は警告を出力する。
 
 **ステータス更新**（`--auto` モード時）: ステータスファイル（`/tmp/{project}-flow-{ownerRepo}-{issue番号}`）が存在する場合、`phase` を `"reviewing"` に更新し、`updated_at` を現在時刻にする。Issue番号はPR番号からPRのbodyに含まれる `Closes #XX` を解析するか、ブランチ名から `{type}/{issue番号}-...` を解析して特定する。いずれの方法でもIssue番号を特定できない場合は、誤ったIssueのステータスを更新しないよう**ステータス更新処理をスキップし、警告を出力する**。ステータスファイルが存在しない場合もスキップする。
 
@@ -303,7 +303,7 @@ gh api --paginate repos/{owner}/{repo}/pulls/{PR番号}/reviews | jq -s '
 
 `gh api repos/{owner}/{repo}/pulls/{PR番号}/requested_reviewers --method POST -f reviewers[]='copilot-pull-request-reviewer[bot]'` でCopilotに再レビューをリクエストする。
 
-**ポーリング再開**（`--auto` モード時）: Copilot再レビューリクエスト完了後、`CronCreate` で新しいポーリングタスクを作成（cron: `*/5 * * * *`, prompt: `/review-respond --auto --max-idle 3`, recurring: true）。新しいタスクIDをcronタスクIDファイル（`/tmp/{project}-review-{ownerRepo}-cron-{PR番号}`）に上書きし、idleカウンターファイルを0にリセットする。
+**ポーリング再開**（`--auto` モード時）: Copilot再レビューリクエスト完了後、`CronCreate` で新しいポーリングタスクを作成（cron: `*/5 * * * *`, prompt: `/review-respond --auto --max-idle 3`, recurring: true）。新しいタスクIDをcronタスクIDファイル（`/tmp/{project}-review-{ownerRepo}-cron-{PR番号}`）に上書きし、idleカウンターファイルを0にリセットする。※ 再開後の `--max-idle` は常に3に固定される（初回実行時に異なる値が指定されていても引き継がれない）。
 
 ### 7. レビューコメントへの返信
 


### PR DESCRIPTION
## Summary

- レビュー対応（コード修正）開始時にポーリングを一時停止（CronDelete）
- Copilot再レビューリクエスト完了後にポーリングを再開（CronCreate）
- 再開時にidleカウンターをリセット

## 変更内容

- `.claude/commands/review-respond.md`: Step 3前にポーリング一時停止、Step 6後にポーリング再開を追加

## Test plan

- [ ] レビュー対応中にポーリングが走らないことを確認
- [ ] Copilot再レビューリクエスト後にポーリングが再開されることを確認
- [ ] 一時停止→再開のサイクルが複数回正常に動作することを確認
- [ ] `--max-idle` のカウントが再開時にリセットされることを確認

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)