### PR TITLE
fix: template-syncワークフローのセットアップ問題を修正

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -8,20 +8,32 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   template-sync:
     runs-on: ubuntu-latest
-    if: github.repository != 'KdavisO/claude-project-template' && secrets.TEMPLATE_SYNC_TOKEN != ''
+    if: github.repository != 'KdavisO/claude-project-template'
+    env:
+      SYNC_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN }}
     steps:
+      - name: Check token
+        if: env.SYNC_TOKEN == ''
+        run: |
+          echo "::warning::TEMPLATE_SYNC_TOKEN is not set. Skipping sync."
+          exit 0
+
       - uses: actions/checkout@v4
+        if: env.SYNC_TOKEN != ''
         with:
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN }}
 
       - uses: AndreasAugustin/actions-template-sync@8ec19a5f2721ffb81ff809aa340ddf75e6a85ea6 # v2
+        if: env.SYNC_TOKEN != ''
         with:
           source_repo_path: KdavisO/claude-project-template
           upstream_branch: main
           pr_title: "chore: テンプレートリポジトリの更新を反映"
           pr_labels: chore,template-sync
           pr_commit_msg: "chore: sync with template repository"
+          github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN }}

--- a/docs/template-sync.md
+++ b/docs/template-sync.md
@@ -44,6 +44,8 @@
    - **Permissions**:
      - Contents: Read and write
      - Pull requests: Read and write
+     - Issues: Read and write（ラベル操作に必要）
+     - Workflows: Read and write（ワークフローファイルの同期に必要）
 3. トークンをコピー
 
 ### 2. ダウンストリームリポジトリにシークレットを追加
@@ -52,14 +54,20 @@
 gh secret set TEMPLATE_SYNC_TOKEN --body "<PAT>"
 ```
 
-### 3. ワークフローファイルの確認
+### 3. リポジトリ設定の確認
+
+ダウンストリームリポジトリの Settings → Actions → General で以下を有効化する:
+
+- **Allow GitHub Actions to create and approve pull requests**: 有効化（同期PRの自動作成に必要）
+
+### 4. ワークフローファイルの確認
 
 テンプレートから作成したリポジトリには、以下のファイルが含まれている:
 
 - `.github/workflows/template-sync.yml` — 同期ワークフロー
 - `.templatesyncignore` — 同期除外ファイルリスト
 
-### 4. 動作確認
+### 5. 動作確認
 
 ```bash
 gh workflow run template-sync.yml


### PR DESCRIPTION
## Summary

- secrets参照をenv変数経由に変更（workflow_dispatchでのバリデーションエラー回避）
- permissions に issues: write を追加（ラベル操作に必要）
- github_tokenパラメータにPATを渡す設定を追加
- セットアップガイドにPAT権限とリポジトリ設定の手順を追記

## 変更内容

- `.github/workflows/template-sync.yml`: secrets参照方法、権限、github_tokenの修正
- `docs/template-sync.md`: PAT権限にIssues/Workflows追加、リポジトリ設定の有効化手順追記

## Test plan

- [ ] `gh workflow run template-sync.yml` でsecrets未設定時に警告が出てスキップされることを確認
- [ ] secrets設定済みリポジトリで同期PRが正常に作成されることを確認
- [ ] PRにラベルが付与されることを確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)