### PR TITLE
feat: .claude/rules/ と CLAUDE.md のパススコープ付き Edit/Write 権限を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,7 +49,11 @@
       "Bash(gh run rerun*)",
       "Bash(bash .claude/scripts/cleanup-shells.sh*)",
       "Edit",
+      "Edit(.claude/rules/**)",
+      "Edit(.claude/CLAUDE.md)",
       "Write",
+      "Write(.claude/rules/**)",
+      "Write(.claude/CLAUDE.md)",
       "Update"
     ],
     "deny": [


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の `permissions.allow` に `.claude/rules/**` と `.claude/CLAUDE.md` へのパススコープ付き Edit/Write 権限を追加
- バックグラウンドエージェントが承認プロンプトなしで `.claude/rules/` と `CLAUDE.md` を編集可能に
- `.claude/settings.json` と `.claude/settings.local.json` は引き続き書き込み保護を維持

## 変更内容

`settings.json` に以下の4行を追加:
- `Edit(.claude/rules/**)`
- `Edit(.claude/CLAUDE.md)`
- `Write(.claude/rules/**)`
- `Write(.claude/CLAUDE.md)`

## Test plan

- [ ] バックグラウンドエージェントが `.claude/rules/` 配下のファイルを承認プロンプトなしで編集できることを確認
- [ ] バックグラウンドエージェントが `.claude/CLAUDE.md` を承認プロンプトなしで編集できることを確認
- [ ] `.claude/settings.json` への書き込みは引き続き承認プロンプトが表示されることを確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)