### PR TITLE
docs: .claude/ 配下の書き込み保護に関する運用ルールを追加

### DIFF
--- a/.claude/rules/claude-dir-protection.md
+++ b/.claude/rules/claude-dir-protection.md
@@ -11,11 +11,13 @@ globs: []
 - `bypassPermissions` モード（Agent ツールの `mode: "bypassPermissions"` で指定する、権限チェックを省略する起動モード）でも `.claude/` への書き込みには承認プロンプトが表示される
 - **例外（保護なし）**: `.claude/commands/`, `.claude/agents/`, `.claude/skills/` は保護対象外
 
-## バックグラウンドエージェントでの注意点
+## バックグラウンド・worktree エージェントでの注意点
 
 - `run_in_background: true` のエージェントが `.claude/` 配下を編集すると、承認プロンプトを受け付けられずスタックする
+- `isolation: "worktree"` で起動した worktree エージェントも、`run_in_background: true` と組み合わせた場合は同様にスタックする
 - 対策: `.claude/` 配下のうちバックグラウンドで編集が必要なパスに対してのみ、パススコープ付き権限で明示的に許可を与える
   - この明示的に許可されたパスでは承認プロンプトなしで書き込みできる（保護をバイパスする）が、それ以外の `.claude/` 配下は引き続き承認プロンプト付きで保護される
+  - worktree エージェントの場合も同じパススコープ付き権限（例: `Edit(.claude/rules/**)` 等）を設定すること
 
 ## 推奨設定パターン
 


### PR DESCRIPTION
## 概要

#44 の調査で明らかになった Claude Code の `.claude/` 配下の書き込み保護仕様を運用ルールとして文書化。バックグラウンドエージェントや worktree エージェントが `.claude/` を編集する際の注意点と推奨設定パターンを記載。

## 変更内容

- `.claude/rules/claude-dir-protection.md` を新規追加
  - Claude Code の `.claude/` 保護仕様（Edit/Write 一般許可では保護がバイパスされない、bypassPermissions でも承認プロンプトが出る、例外パス）
  - バックグラウンドエージェントでの注意点（run_in_background + .claude/ 編集でスタックする問題と対策）
  - 推奨設定パターン（許可すべきパスと保護維持すべきパス）

## テスト方法

- [ ] `.claude/rules/claude-dir-protection.md` が正しいフォーマット（frontmatter付き）で配置されていること
- [ ] 内容が Issue #46 の受け入れ条件を満たしていること

Closes #46