### PR TITLE
fix: Copilot レビューリクエストの並列実行時レースコンディション対策

### DIFF
--- a/.claude/commands/issue-pr.md
+++ b/.claude/commands/issue-pr.md
@@ -48,10 +48,14 @@ Closes #{issue番号}
 
 6. PR作成後、Copilotレビューをリクエストし、成功を確認する:
 
-   1. レビューリクエストを送信:
+   1. レビューリクエストをPOST送信し、レスポンス/エラーをキャプチャする:
       ```bash
-      gh api repos/{owner}/{repo}/pulls/{PR番号}/requested_reviewers --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+      RESPONSE=$(gh api repos/{owner}/{repo}/pulls/{PR番号}/requested_reviewers \
+        --method POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>&1)
+      EXIT_CODE=$?
       ```
+      - `EXIT_CODE` が 0 以外 → エラーレスポンスを `RESPONSE` からログ出力し、リトライへ
+      - `EXIT_CODE` が 0 → 確認へ
 
    2. リクエストが成功したか確認（`requested_reviewers` にCopilotが含まれているか）:
       ```bash
@@ -60,8 +64,10 @@ Closes #{issue番号}
       - 1以上 → 成功。手順7へ進む
       - 0 → リトライへ
 
-   3. リトライ（最大3回、5秒間隔。初回リクエストを含めて合計4回まで試行する）:
-      - 上記 1 → 2 を繰り返す
+   3. リトライ（最大3回、指数バックオフ。初回リクエストを含めて合計4回まで試行する）:
+      - **POSTリクエスト自体を再送する**（確認のみの再試行ではなく、上記 1 → 2 の全手順を繰り返す）
+      - 待機時間は指数バックオフ: 1回目リトライ=5秒、2回目=10秒、3回目=20秒
+      - 各リトライ時にエラー内容をログ出力する（例: `「リトライ 1/3: 前回エラー: 422 - {エラー内容}」`）
       - 3回リトライ（合計4回試行）しても `requested_reviewers` にCopilotが含まれない場合:
         - `--auto` モード: 「⚠ Copilotレビューリクエストの確認に失敗しました。手動でレビューをリクエストしてください」と警告を出力し、**ポーリングは開始しない**（空振りが確定しているため）
         - 通常モード: 同様の警告を出力

--- a/.claude/commands/parallel-suggest.md
+++ b/.claude/commands/parallel-suggest.md
@@ -174,6 +174,10 @@ Issue #{issue番号}「{Issueタイトル}」を実装してください。
 5. セルフレビュー・コミット（git-conventions.md に従う）
 
 6. PR作成・自動レビューフロー:
+   - Copilotレビューリクエストの並列実行によるレースコンディションを回避するため、PR作成前にランダムディレイ（3〜8秒）を挿入する:
+     ```bash
+     sleep $((RANDOM % 6 + 3))
+     ```
    - `/issue-pr --auto {issue番号}` を実行してPRを作成する（Copilotレビューリクエスト・レビュー対応ポーリングの「開始」までを含む）
    - `/issue-pr --auto` の成功後、ステータスファイルを更新（原子的書き換え）: 手順2で使用した STATUS_FILE / STATUS_FILE_TMP を用い、`.tmp` に書き出してから `mv` で置き換える手順で、phase を "pr-created" に、pr フィールドにPR番号を設定し、updated_at を現在時刻に更新する
    - Copilotレビューリクエストが成功した場合、`/issue-pr --auto` が自動で `/loop ... /review-respond --auto --max-idle 3` によるレビュー対応ポーリングを開始する。このポーリングはcronでバックグラウンド実行され、`/issue-pr --auto` 自体はポーリング完了まで同期的には待機しない


### PR DESCRIPTION
## 概要

並列PR作成時にCopilotレビューリクエストが422エラーで失敗する問題を修正。リトライロジックの設計ミス（確認のみ再試行でPOST再送なし）と、並列リクエスト時のレースコンディションに対策を実施。

## 変更内容

- `.claude/commands/issue-pr.md`:
  - POSTレスポンス/エラーをキャプチャしてログ出力するよう変更
  - リトライ時にPOSTリクエスト自体を再送するよう修正（確認のみの再試行から変更）
  - 固定5秒間隔から指数バックオフ（5秒→10秒→20秒）に変更
  - 各リトライ時にエラー内容をログ出力

- `.claude/commands/parallel-suggest.md`:
  - チームメイトテンプレートのPR作成前にランダムディレイ（3〜8秒）を追加
  - 並列PR作成時のCopilotリクエスト間の時間差を確保してレースコンディションを回避

## テスト方法

- `/parallel-suggest` で複数PRを同時作成し、全PRでCopilotレビューリクエストが成功することを確認
- 単体PRでの `/issue-pr` 実行時にリトライロジックが正しく動作することを確認

Closes #70