### PR TITLE
feat: PreToolUse プロンプト強化フックのサンプル追加

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -213,14 +213,13 @@ cd claude-code-prompt-improver
 
 # 依存関係をインストール（ローカル端末で実行）
 pnpm install
-
-# グローバルにリンク（任意）
-pnpm link --global
 ```
 
 **settings.json への設定例:**
 
-既存の `.claude/settings.json` には `hooks.SessionEnd` などの設定が含まれている場合があります。以下は `hooks` オブジェクト内に `PreToolUse` を追記する例です。既存の `hooks` エントリを上書きしないよう注意してください:
+既存の `.claude/settings.json` には `hooks.SessionEnd` などの設定が含まれている場合があります。以下は `hooks` オブジェクト内に `PreToolUse` を追記する例です。既存の `hooks` エントリを上書きしないよう注意してください。
+
+`matcher` はフックを適用するツール名のパターンを指定します（例: `"Task"` は TaskCreate/TaskUpdate 等のツール呼び出しにマッチ）。すべてのツールに適用する場合は `matcher` を省略するか `"*"` を指定してください。`command` にはクローンしたリポジトリ内のスクリプトの絶対パスを指定します:
 
 ```json
 {


### PR DESCRIPTION
## 概要

SETUP.md に PreToolUse フックを活用したプロンプト強化の説明セクションを追加。曖昧なプロンプトを自動で詳細化するコミュニティツールの紹介とインストール手順を記載。

## 変更内容

- `SETUP.md`: PreToolUse プロンプト強化フック（オプション）セクションを追加
  - フックの仕組みの説明
  - コミュニティツール（severity1/claude-code-prompt-improver）の紹介とインストール手順
  - settings.json への設定例（ドキュメントとして記載。JSONはコメント不可のため直接追加はしない）
  - 外部依存のためオプション扱いであることを明記

## テスト方法

- [ ] SETUP.md の新セクションが正しくレンダリングされることを確認
- [ ] 設定例の JSON が有効な構文であることを確認
- [ ] 外部リンク（GitHub リポジトリ、ドキュメント）が有効であることを確認

Closes #80