### PR TITLE
chore: template-sync workflowのgithub_tokenをsource_gh_tokenに変更

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -36,4 +36,4 @@ jobs:
           pr_title: "chore: テンプレートリポジトリの更新を反映"
           pr_labels: chore,template-sync
           pr_commit_msg: "chore: sync with template repository"
-          github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN }}
+          source_gh_token: ${{ secrets.TEMPLATE_SYNC_TOKEN }}


### PR DESCRIPTION
## 概要

actions-template-sync アクションの非推奨パラメータ `github_token` を推奨パラメータ `source_gh_token` に移行。

## 変更内容

- `.github/workflows/template-sync.yml`: `github_token` → `source_gh_token` に変更（1箇所）

## テスト方法

- [ ] workflow実行時に `github_token` の非推奨警告が出なくなることを確認

Closes #88