### PR TITLE
feat: PostToolUse品質ゲートフックの導入

### DIFF
--- a/.claude/rules/quality-gate-hooks.md
+++ b/.claude/rules/quality-gate-hooks.md
@@ -33,7 +33,7 @@ globs: []
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi; true",
+            "command": "if printf '%s' \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi; true",
             "timeout": 30
           }
         ]
@@ -65,7 +65,7 @@ globs: []
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi; true",
+            "command": "if printf '%s' \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi; true",
             "timeout": 30
           }
         ]

--- a/.claude/rules/quality-gate-hooks.md
+++ b/.claude/rules/quality-gate-hooks.md
@@ -48,7 +48,7 @@ globs: []
 - `Bash` ツールで `git commit` が実行された後に発火
 - `pnpm lint --quiet` を実行し、エラーがあれば stdout に出力
 - Claude はこの出力を読み取り、lint エラーを自動修正する
-- `|| true` により、lint エラーがあってもフック自体は成功として扱う（Claude にフィードバックが伝わる）
+- `|| true` で `pnpm lint --quiet` の非 0 終了コードを吸収し、末尾の `; true` により条件不一致時も含めてフック全体は成功として扱う（Claude にフィードバックが伝わる）
 
 ## Phase 2: TypeScript ファイル編集時の型チェック
 

--- a/.claude/rules/quality-gate-hooks.md
+++ b/.claude/rules/quality-gate-hooks.md
@@ -7,7 +7,7 @@ globs: []
 
 ## 概要
 
-`PostToolUse` フックを利用して、コミット前に lint・型チェックを自動実行する。エラーがあれば stdout でフィードバックし、Claude が自動修正する。
+`PostToolUse` フックを利用して、コミット時（実行直後）やファイル編集後に lint・型チェックを自動実行する。エラーがあれば stdout でフィードバックし、Claude が自動修正する。
 
 ## reactive-hooks.md との住み分け
 
@@ -33,7 +33,7 @@ globs: []
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi; true",
             "timeout": 30
           }
         ]
@@ -65,7 +65,7 @@ globs: []
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi; true",
             "timeout": 30
           }
         ]
@@ -97,7 +97,8 @@ globs: []
 
 ### エラーハンドリング
 
-- フックコマンドは `|| true` で終了コードを 0 にする（フック失敗によるセッション中断を防止）
+- フックコマンドは終了コードが常に 0 になるように構成する（フック失敗によるセッション中断を防止）
+- `|| true` を使う場合は一部のコマンドではなくフック全体に効く位置に置く。条件分岐を使う場合も、末尾に `; true` を付ける、または `else :` を入れるなどして、条件不一致時を含めて必ず 0 で終了させる
 - lint/型チェックのエラーは stdout 経由で Claude にフィードバックされるため、exit code による制御は不要
 - `2>&1` で stderr も stdout にマージし、エラーメッセージが確実に Claude に伝わるようにする
 

--- a/.claude/rules/quality-gate-hooks.md
+++ b/.claude/rules/quality-gate-hooks.md
@@ -1,0 +1,119 @@
+---
+description: PostToolUseフックによるlint・型チェック自動実行の品質ゲート運用ガイドライン
+globs: []
+---
+
+# PostToolUse 品質ゲートフック運用ガイドライン
+
+## 概要
+
+`PostToolUse` フックを利用して、コミット前に lint・型チェックを自動実行する。エラーがあれば stdout でフィードバックし、Claude が自動修正する。
+
+## reactive-hooks.md との住み分け
+
+| 観点 | reactive-hooks（環境同期） | quality-gate-hooks（品質ゲート） |
+| --- | --- | --- |
+| イベント | `CwdChanged` / `FileChanged` | `PostToolUse` |
+| 目的 | 環境変数の自動リロード | lint・型エラーの自動検出 |
+| タイミング | ディレクトリ移動時・ファイル変更時 | ツール実行後 |
+| 対象 | `.env` / `.envrc` | `git commit` / `.ts` ファイル編集 |
+
+## Phase 1: コミット時 lint 自動実行
+
+`Bash` ツール実行後、`git commit` コマンドにマッチした場合に lint を自動実行する。
+
+### 設定例
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 動作
+
+- `Bash` ツールで `git commit` が実行された後に発火
+- `pnpm lint --quiet` を実行し、エラーがあれば stdout に出力
+- Claude はこの出力を読み取り、lint エラーを自動修正する
+- `|| true` により、lint エラーがあってもフック自体は成功として扱う（Claude にフィードバックが伝わる）
+
+## Phase 2: TypeScript ファイル編集時の型チェック
+
+`.ts` / `.tsx` ファイル編集後に `tsc --noEmit` を自動実行する。
+
+### 設定例
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 動作
+
+- `Edit` または `Write` ツールで `.ts` / `.tsx` ファイルが編集された後に発火
+- `tsc --noEmit` を実行し、型エラーがあれば先頭20行を stdout に出力
+- `head -20` で出力を制限し、大量の型エラーでコンテキストを圧迫しない
+
+## 設計指針
+
+### タイムアウト
+
+- **30秒以内** を推奨（Phase 1・Phase 2 共通）
+- 大規模プロジェクトで lint/型チェックに時間がかかる場合は、対象ディレクトリを限定するか `--cache` オプションを活用する
+- タイムアウト超過時はフックが強制終了され、Claude にはタイムアウトした旨が通知される
+
+### matcher の設定
+
+- `"Bash"`: Bash ツール実行後にのみ発火（コミット時 lint）
+- `"Edit|Write"`: Edit/Write ツール実行後にのみ発火（型チェック）
+- matcher を省略すると全ツールで発火するため、必ず指定すること
+
+### エラーハンドリング
+
+- フックコマンドは `|| true` で終了コードを 0 にする（フック失敗によるセッション中断を防止）
+- lint/型チェックのエラーは stdout 経由で Claude にフィードバックされるため、exit code による制御は不要
+- `2>&1` で stderr も stdout にマージし、エラーメッセージが確実に Claude に伝わるようにする
+
+### 冪等性
+
+- lint・型チェックは副作用がなく、何度実行しても同じ結果を返す
+- `--fix` オプションはフック内では使用しない（自動修正は Claude に任せる）
+
+## 段階的導入の推奨
+
+1. まず Phase 1（コミット時 lint）のみ導入し、動作を確認する
+2. タイムアウトや誤発火がないことを確認してから Phase 2（型チェック）を追加する
+3. プロジェクトの lint/型チェックの実行時間に応じてタイムアウト値を調整する
+
+## 注意事項
+
+- フック設定はプロジェクト固有のため、`.claude/settings.local.json` に追記することを推奨（テンプレート管理の `.claude/settings.json` を上書きしない）
+- `CLAUDE_TOOL_INPUT` 環境変数はフック実行時に自動設定される（ツールに渡された入力内容）
+- フックは同期実行のため、長時間かかるコマンドはセッションの応答性に影響する

--- a/SETUP.md
+++ b/SETUP.md
@@ -551,7 +551,7 @@ PostToolUse フックを使い、コミット時（実行直後）の lint や�
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi; true",
+            "command": "if printf '%s' \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi; true",
             "timeout": 30
           }
         ]
@@ -574,7 +574,7 @@ PostToolUse フックを使い、コミット時（実行直後）の lint や�
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi; true",
+            "command": "if printf '%s' \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi; true",
             "timeout": 30
           }
         ]

--- a/SETUP.md
+++ b/SETUP.md
@@ -536,7 +536,7 @@ Claude がディレクトリを移動するたびに `direnv export bash` を実
 
 ## PostToolUse 品質ゲートフック（オプション）
 
-PostToolUse フックを使い、コミット前の lint やファイル編集後の型チェックを自動実行できます。エラーがあれば Claude にフィードバックされ、自動修正が促されます。
+PostToolUse フックを使い、コミット時（実行直後）の lint やファイル編集後の型チェックを自動実行できます。エラーがあれば Claude にフィードバックされ、自動修正が促されます。
 
 ### Phase 1: コミット時 lint 自動実行
 
@@ -551,7 +551,7 @@ PostToolUse フックを使い、コミット前の lint やファイル編集�
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi; true",
             "timeout": 30
           }
         ]
@@ -574,7 +574,7 @@ PostToolUse フックを使い、コミット前の lint やファイル編集�
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi; true",
             "timeout": 30
           }
         ]

--- a/SETUP.md
+++ b/SETUP.md
@@ -24,6 +24,7 @@ gh repo create <new-repo> --template KdavisO/claude-project-template --public
 | `.claude/rules/git-conventions.md`     | `{github_username}`, reviewer                | assignee/reviewer を変更                                                         |
 | `.claude/rules/project-structure.md`   | 全体                                         | プロジェクト構造に合わせて書き換え                                               |
 | `.claude/rules/reactive-hooks.md`      | ユースケース・スクリプト例                   | プロジェクトのディレクトリ構成・環境管理方法に合わせる                           |
+| `.claude/rules/quality-gate-hooks.md`  | lint・型チェックコマンド、タイムアウト値     | プロジェクトの lint/型チェック設定に合わせてカスタマイズ                          |
 | `.github/release.yml`                  | カテゴリ・ラベル                             | プロジェクトのラベルに合わせてリリースノートのカテゴリを変更                     |
 | `.claudeignore`                        | 除外パターン                                 | プロジェクトの技術スタックに合わせて不要なパターンを削除・追加                   |
 | `.github/copilot-instructions.md`      | Focus Areas・Skip These                      | プロジェクトのレビュー方針・セキュリティ要件に合わせてカスタマイズ               |
@@ -532,6 +533,69 @@ Claude がディレクトリを移動するたびに `direnv export bash` を実
 - `.env` の直接 source は簡易的な方法であり、複雑な環境設定には direnv の使用を推奨
 - `env` コマンドで全環境変数を出力すると機密情報がログに残る可能性があるため、必要なキーのみを明示的に出力すること
 - フック活用のベストプラクティスは `.claude/rules/reactive-hooks.md` を参照
+
+## PostToolUse 品質ゲートフック（オプション）
+
+PostToolUse フックを使い、コミット前の lint やファイル編集後の型チェックを自動実行できます。エラーがあれば Claude にフィードバックされ、自動修正が促されます。
+
+### Phase 1: コミット時 lint 自動実行
+
+`Bash` ツールで `git commit` 実行後に `pnpm lint` を自動実行します:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'git commit'; then pnpm lint --quiet 2>&1 || true; fi",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Phase 2: TypeScript 型チェック
+
+`Edit` / `Write` ツールで `.ts` / `.tsx` ファイル編集後に `tsc --noEmit` を自動実行します:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '\\.(ts|tsx)'; then pnpm tsc --noEmit 2>&1 | head -20 || true; fi",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 導入手順
+
+1. `.claude/settings.local.json`（プロジェクトローカル設定）の `hooks.PostToolUse` セクションに上記の設定を追記する（テンプレート管理の `.claude/settings.json` を上書きしないよう注意）
+2. まず Phase 1（lint）のみ導入し、動作を確認する
+3. Phase 2（型チェック）はプロジェクトに TypeScript がある場合のみ追加する
+4. タイムアウト値（デフォルト 30秒）はプロジェクトの lint/型チェック実行時間に応じて調整する
+
+### カスタマイズ
+
+- パッケージマネージャが `pnpm` 以外の場合は `npm` / `yarn` に置き換える
+- lint コマンドが `eslint` 直接実行の場合は `pnpm lint` を `npx eslint .` 等に変更する
+- 運用ガイドラインの詳細は `.claude/rules/quality-gate-hooks.md` を参照
 
 ## PreToolUse プロンプト強化フック（オプション）
 


### PR DESCRIPTION
## Summary

- PostToolUse フックによる lint・型チェック自動実行の設定テンプレートとガイドラインを導入
- Phase 1（コミット時 lint）と Phase 2（TypeScript 型チェック）の段階的導入を推奨
- 既存の reactive-hooks.md（環境同期）との住み分けを明確化

## 変更内容

### 新規ファイル
- `.claude/rules/quality-gate-hooks.md`: PostToolUse 品質ゲートフック運用ガイドライン

### ドキュメント更新
- `SETUP.md`: 品質ゲートフックセクション追加、書き換え箇所一覧テーブルに追記

### 要件との差分について
Issue #113 の受け入れ条件に「settings.json にサンプル設定を追加」とあるが、品質ゲートフックはプロジェクト固有（lint/型チェックコマンドが異なる）のため、テンプレート共有の `.claude/settings.json` には追加せず、`SETUP.md` と `.claude/rules/quality-gate-hooks.md` に設定例を記載する方式とした。導入時は `.claude/settings.local.json` に追記する手順を明記。

## Test plan

- [ ] `.claude/rules/quality-gate-hooks.md` が正しく配置されている
- [ ] SETUP.md の品質ゲートフックセクションに Phase 1/2 の設定例が含まれている
- [ ] フックコマンドが条件不一致時も含め常に終了コード 0 を返すこと

Closes #113