### PR TITLE
docs: SETUP.mdのtemplate-sync用PAT権限を完全列挙

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -895,7 +895,7 @@ Claude Code のカスタムステータスラインを使って、セッショ�
 4. `.claude/rules/project-structure.md` にプロジェクト固有のルールを記載
 5. 必要に応じて `.claude/skills/` にプロジェクト固有のスキルを追加
 6. テンプレート同期を有効化（[docs/template-sync.md](docs/template-sync.md) 参照）:
-   - `gh secret set TEMPLATE_SYNC_TOKEN` でテンプレート同期用PATを設定（必要な権限: Contents R/W, Pull requests R/W）
+   - `gh secret set TEMPLATE_SYNC_TOKEN` でテンプレート同期用PATを設定（必要な権限: Contents R/W, Pull requests R/W, Issues R/W, Workflows R/W）。権限が不足すると `.github/workflows/template-sync.yml` 自体の同期時にpushが拒否される等の失敗が発生するため、詳細は [docs/template-sync.md](docs/template-sync.md#1-personal-access-token-pat-の作成) を参照
    - `.templatesyncignore` にプロジェクト固有ファイルを追加（例: `.claude/CLAUDE.md`, `.claude/settings.json`）。`.claudeignore` をカスタマイズする場合はダウンストリーム側の `.templatesyncignore` にも `.claudeignore` を追加すること（テンプレート側の `.templatesyncignore` は同期されないため）。詳細は [docs/template-sync.md](docs/template-sync.md) の該当セクションを参照
    - `gh workflow run template-sync.yml` で動作確認
 7. この `SETUP.md` は書き換え完了後に削除してOK


### PR DESCRIPTION
## 概要

`SETUP.md` の template-sync 用 PAT 権限の記載が `docs/template-sync.md` と不整合で、`Issues` / `Workflows` スコープが欠落していた。実際にこの記載に従って PAT を作成したダウンストリームリポジトリで `.github/workflows/template-sync.yml` 自体の同期 push が拒否される事例が発生している。

## 変更内容

- `SETUP.md` L898: PAT に必要な権限を 4 つ完全列挙
  - Contents R/W
  - Pull requests R/W
  - Issues R/W
  - Workflows R/W
- 権限不足時に発生する症状（ワークフローファイル同期時の push 拒否）の説明と、詳細セクションへのアンカーリンクを追加

## テスト方法

- `SETUP.md` の記載が `docs/template-sync.md` L47-51 と整合していることを目視確認
- 追加したアンカーリンク `#1-personal-access-token-pat-の作成` が `docs/template-sync.md` L42 の H3 見出しと一致することを確認

Closes #136