### PR TITLE
docs: SETUP.md書き換え箇所一覧に.claude/skills/行を追加

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -30,6 +30,7 @@ gh repo create <new-repo> --template KdavisO/claude-project-template --public
 | `.github/copilot-instructions.md`      | Focus Areas・Skip These                      | プロジェクトのレビュー方針・セキュリティ要件に合わせてカスタマイズ               |
 | `.env.sample`                          | 環境変数エントリ                             | プロジェクト固有の環境変数を追記（必要に応じて下流の `.templatesyncignore` で保護） |
 | `.gitignore`                           | プロジェクト固有の除外パターン               | `node_modules/`, `dist/`, `build/` 等、プロジェクトの技術スタックに合わせて追記（テンプレートは `.env*` と汎用ノイズのみ同梱） |
+| `.claude/skills/`                      | 不要スキルの削除・独自スキルの追加           | 詳細と各スキルの前提ツール（Semgrep / CodeQL / Codex CLI / Gemini CLI 等）は下記「`.claude/skills/` ディレクトリ」セクション参照 |
 
 **レビュワー名に関する注記:** `.claude/rules/git-conventions.md` ではassignee/reviewerの短縮名を、`.claude/commands/issue-pr.md` と `.claude/commands/review-respond.md` では正式名 `copilot-pull-request-reviewer[bot]` を使用しています。テンプレート展開時は、使用するレビュワーに合わせて**両方のファイル**を統一的に変更してください。
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -30,7 +30,7 @@ gh repo create <new-repo> --template KdavisO/claude-project-template --public
 | `.github/copilot-instructions.md`      | Focus Areas・Skip These                      | プロジェクトのレビュー方針・セキュリティ要件に合わせてカスタマイズ               |
 | `.env.sample`                          | 環境変数エントリ                             | プロジェクト固有の環境変数を追記（必要に応じて下流の `.templatesyncignore` で保護） |
 | `.gitignore`                           | プロジェクト固有の除外パターン               | `node_modules/`, `dist/`, `build/` 等、プロジェクトの技術スタックに合わせて追記（テンプレートは `.env*` と汎用ノイズのみ同梱） |
-| `.claude/skills/`                      | 不要スキルの削除・独自スキルの追加           | 詳細と各スキルの前提ツール（Semgrep / CodeQL / Codex CLI / Gemini CLI 等）は下記「`.claude/skills/` ディレクトリ」セクション参照 |
+| `.claude/skills/`                      | 不要スキルの削除・独自スキルの追加           | 詳細と各スキルの前提ツール（Semgrep / CodeQL / Codex CLI / Gemini CLI 等）は [`.claude/skills/` ディレクトリ](#claudeskills-ディレクトリ) セクション参照 |
 
 **レビュワー名に関する注記:** `.claude/rules/git-conventions.md` ではassignee/reviewerの短縮名を、`.claude/commands/issue-pr.md` と `.claude/commands/review-respond.md` では正式名 `copilot-pull-request-reviewer[bot]` を使用しています。テンプレート展開時は、使用するレビュワーに合わせて**両方のファイル**を統一的に変更してください。
 


### PR DESCRIPTION
## Summary

- SETUP.md 冒頭「書き換え箇所一覧」テーブル末尾に `.claude/skills/` 行を追加
- テンプレート展開ユーザーが冒頭テーブルだけを見て作業した際に `.claude/skills/` 配下（TDD・レビュー・セキュリティ系6種）の取捨選択を見落とすリスクを解消
- 各スキルの前提ツール（Semgrep / CodeQL / Codex CLI / Gemini CLI）への言及と、L755 以降の詳細セクションへの誘導を含める

Closes #141

## 変更内容

### `SETUP.md`

書き換え箇所一覧テーブル（L32 直下）に以下の1行を追加:

\`\`\`markdown
| \`.claude/skills/\`                      | 不要スキルの削除・独自スキルの追加           | 詳細と各スキルの前提ツール（Semgrep / CodeQL / Codex CLI / Gemini CLI 等）は下記「\`.claude/skills/\` ディレクトリ」セクション参照 |
\`\`\`

### 維持した既存内容

- L755 以降の `.claude/skills/` ディレクトリ セクション（各スキル説明・前提ツール表・カスタマイズ手順）は変更なし
- 重複記載を避け、冒頭テーブルは誘導のみに留める設計

## 受け入れ条件の達成状況

- [x] 冒頭テーブルに `.claude/skills/` 行を追加
- [x] セキュリティスキルの前提ツール（Semgrep / CodeQL / Codex CLI / Gemini CLI）への言及
- [x] 既存の L755 以降セクションへの誘導のみに留め、重複記載を回避

## 実装前分析

### エッジケース

- Markdown テーブルの列幅・記号を既存行と揃えた（`|` 区切り・スペース埋め）
- 行の追加位置: `.gitignore` 行の直後 = 既存のセットアップ論理順序（設定ファイル → プロジェクト固有ファイル → `.claude/skills/`）を壊さない

### テストケース（手動確認）

- [ ] SETUP.md 冒頭テーブルに `.claude/skills/` 行が表示されること
- [ ] L755 以降の既存セクションに影響がないこと（diff 1行追加のみ）
- [ ] GitHub のプレビューでテーブルが崩れないこと

### 設計上の懸念点

- なし（テーブル行追加のみで副作用なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)