### PR TITLE
copilot-instructions.md の Skip These を具体化しレビュー指摘の境界を明確化

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,7 @@ The following categories should NOT be flagged in reviews. The guiding principle
 
 - Whitespace, indentation style, trailing commas, semicolons
 - Import ordering or grouping
-- Naming conventions (e.g., camelCase vs snake_case) — covered by self-review and linter
+- Naming conventions (e.g., camelCase vs snake_case) — covered by self-review and, where applicable, linter/tooling
 - Comment style, JSDoc completeness, or documentation wording
 - Minor refactoring suggestions that don't affect correctness (e.g., "extract this into a helper")
 
@@ -63,8 +63,8 @@ These are style preferences, NOT correctness issues:
 
 ### Diff Display Artifacts
 
-- **Escaped characters in diffs are NOT file content errors.** Git diff output may display escape sequences (e.g., `\"`, `\\n`) that do not exist in the actual file. Do not flag these as issues unless you have verified the raw file content contains the problematic escaping.
-- Example false positive: a diff showing `{ \"key\": \"value\" }` — this is diff rendering, not a JSON escaping error in the source file
+- **Do not assume escaped characters in diffs are rendering artifacts.** In standard git/GitHub diffs, displayed content should normally be treated as the actual file content for that commit, and sequences such as `\"` or `\\n` often legitimately appear in string literals, serialized JSON, or other escaped contexts.
+- False positives here are limited to cases where a viewer/rendering layer is ambiguous or where the diff is showing JSON-inside-a-string or another nested escaped representation. If you suspect that, verify using GitHub's **View file** or raw view for the same commit before dismissing or flagging the escaping as a bug.
 
 ### Boundary: When Consistency IS a Valid Finding
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ This project uses Claude Code for implementation and self-review. Copilot serves
 
 ## Skip These
 
-The following categories should NOT be flagged in reviews. The guiding principle: **skip stylistic preferences; flag only issues that affect correctness, security, or runtime behavior.**
+The following categories should NOT be flagged in reviews. The guiding principle: **skip stylistic preferences; flag issues that affect correctness, security, reliability, type safety, testability, or architecture/design.**
 
 ### Formatting & Style
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,11 +43,36 @@ This project uses Claude Code for implementation and self-review. Copilot serves
 
 ## Skip These
 
-- Code style / formatting (unless it directly impacts readability or correctness)
-- Naming conventions (covered by self-review)
-- Import ordering
-- Comment style or documentation completeness
-- Minor refactoring suggestions that don't affect correctness
+The following categories should NOT be flagged in reviews. The guiding principle: **skip stylistic preferences; flag only issues that affect correctness, security, or runtime behavior.**
+
+### Formatting & Style
+
+- Whitespace, indentation style, trailing commas, semicolons
+- Import ordering or grouping
+- Naming conventions (e.g., camelCase vs snake_case) — covered by self-review and linter
+- Comment style, JSDoc completeness, or documentation wording
+- Minor refactoring suggestions that don't affect correctness (e.g., "extract this into a helper")
+
+### Document & Markdown Consistency
+
+These are style preferences, NOT correctness issues:
+
+- **Heading hierarchy variations**: e.g., a section using 4 subsections vs 5 subsections, or `###` vs `####` for similar content — these do not affect functionality
+- **Reference path style mixing**: e.g., full path (`docs/specs/jwt-auth.md`) vs short name (`jwt-auth.md`) within the same document — both are valid if the target is unambiguous
+- **Markdown formatting differences**: e.g., fenced code block style (`` ``` `` vs `~~~`), list marker style (`-` vs `*`), emphasis style (`**` vs `__`)
+
+### Diff Display Artifacts
+
+- **Escaped characters in diffs are NOT file content errors.** Git diff output may display escape sequences (e.g., `\"`, `\\n`) that do not exist in the actual file. Do not flag these as issues unless you have verified the raw file content contains the problematic escaping.
+- Example false positive: a diff showing `{ \"key\": \"value\" }` — this is diff rendering, not a JSON escaping error in the source file
+
+### Boundary: When Consistency IS a Valid Finding
+
+Flag consistency issues ONLY when they cause one of the following:
+
+- **Broken references**: a path, link, or cross-reference that points to a non-existent target
+- **Contradictory statements**: two sections that make incompatible claims about the same behavior
+- **Misleading examples**: a code example that would fail if copy-pasted (syntax errors, missing imports, wrong API usage)
 
 ## Commit Conventions
 


### PR DESCRIPTION
## 概要

copilot-instructions.md の "Skip These" セクションが抽象的で、Copilot が「correctness に影響する一貫性の問題」と判断して見出し階層や参照パス表記などを指摘し続けていた問題を解消する。スキップ対象を具体的なサブカテゴリに分割し、指摘対象との境界を明文化した。

## 変更内容

- `.github/copilot-instructions.md`
  - **Formatting & Style**: コードスタイル・命名規則・インポート順などの従来項目を整理
  - **Document & Markdown Consistency**: 見出し階層・参照パス表記・Markdown記法の差異をスキップ対象として明示（PR #134, #152 の再指摘対策）
  - **Diff Display Artifacts**: diff表示上のエスケープを実ファイルの問題と混同しないよう注記（PR #128 の誤検知対策）
  - **Boundary: When Consistency IS a Valid Finding**: 壊れた参照・矛盾する記述・コピペで失敗する例のみを指摘対象として境界を明確化

## テスト方法

- [ ] 変更後の copilot-instructions.md が構文的に正しいMarkdownであること
- [ ] 今後のPRでCopilotが見出し階層・参照パス表記・エスケープ表記について不要な指摘をしないこと（実際のレビューで検証）

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)